### PR TITLE
add a negative karma scoreboard

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -36,7 +36,21 @@ async def get_top_karma(limit: int) -> [(int, int, int)]:
         async with connection.execute("SELECT u.discord_id, k.positive, k.negative "
                                       "FROM user u "
                                       "JOIN karma k ON u.id = k.user_id "
+                                      "WHERE k.positive <> 0 OR k.negative <> 0 "
                                       "ORDER BY (k.positive - k.negative) DESC "
+                                      "LIMIT ?;", [limit]) as cursor:
+            leaders = await cursor.fetchall()
+            return leaders if leaders else []
+
+
+# Get the leading negative karma users
+async def get_reversed_top_karma(limit: int) -> [(int, int, int)]:
+    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
+        async with connection.execute("SELECT u.discord_id, k.positive, k.negative "
+                                      "FROM user u "
+                                      "JOIN karma k ON u.id = k.user_id "
+                                      "WHERE k.positive <> 0 OR k.negative <> 0 "
+                                      "ORDER BY (k.positive - k.negative) ASC "
                                       "LIMIT ?;", [limit]) as cursor:
             leaders = await cursor.fetchall()
             return leaders if leaders else []


### PR DESCRIPTION
In this PR the following things have been added:
- The total karma count is displayed
- A command to check which people have the lowest karma

In this PR the following things have been fixed:
- People with 0 positives and 0 negatives are not displayed anymore
- Use enum.Enum instead of discord.Enum
- Some very common mistakes in the karma commands are now recognized as aliases