### PR TITLE
add a dasmooi forward feature

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -2,7 +2,6 @@ import enum
 import io
 import random
 
-import aiohttp
 import discord
 from discord import File
 from discord.ext import commands
@@ -187,13 +186,8 @@ class Fun(commands.Cog):
 
 # Turn attachments into files
 async def to_files(attachments):
-    files = []
-
-    for attachment in attachments:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(attachment.url) as resp:
-                files.append(File(io.BytesIO(await resp.read()), filename=attachment.filename))
-    return files
+    return [File(io.BytesIO(await attachment.read()), filename=attachment.filename)
+            for attachment in attachments]
 
 
 def setup(bot):

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,7 +1,6 @@
 import enum
 import io
 import random
-import urllib
 
 import aiohttp
 import discord
@@ -10,6 +9,13 @@ from discord.ext import commands
 from discord.ext.commands import Context
 
 from backend import database
+
+
+def is_in_guild(guild_id):
+    async def predicate(ctx):
+        return ctx.guild and ctx.guild.id == guild_id
+
+    return commands.check(predicate)
 
 
 class Fun(commands.Cog):
@@ -79,7 +85,8 @@ class Fun(commands.Cog):
 
     # The base command for the dasmooi settings
     @commands.group(name='dasmooi')
-    @commands.is_owner()
+    @is_in_guild(613755161633882112)
+    @commands.has_role('Committee')
     async def on_update_das_mooi_settings(self, ctx):
         if ctx.invoked_subcommand is None:
             await ctx.send('Please use one of the following subcommands: '

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,7 +1,11 @@
 import enum
+import io
 import random
+import urllib
 
+import aiohttp
 import discord
+from discord import File
 from discord.ext import commands
 from discord.ext.commands import Context
 
@@ -12,6 +16,7 @@ class Fun(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.enabled = True
         self.bot = bot
+        self.forwarded_messages = []
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -43,6 +48,17 @@ class Fun(commands.Cog):
                        "<:tegel2:634119528330035200>"
                        "<:tegel1:634119528439218206>")
 
+    # Replies "Alexa, play Despacito" to messages containing "this is so sad"
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if not self.enabled:
+            return
+        if message.author.bot:
+            return
+        if not "this is so sad" in message.content.lower():
+            return
+        await message.channel.send("Alexa, play Despacito")
+
     # Send the leaderboards in the following format:
     # {ranking}. {name} - {score} ({positives} Positives and {negatives} Negatives)
     @commands.command(name='wiezijnhetmooist',
@@ -60,6 +76,33 @@ class Fun(commands.Cog):
     async def on_karma_worst_leaderboard_request(self, ctx: Context):
         message = self.order_leaderboard(await database.get_reversed_top_karma(10))
         await ctx.send(message if message else "Why don't you guys hate someone?")
+
+    # The base command for the dasmooi settings
+    @commands.group(name='dasmooi')
+    async def on_update_das_mooi_settings(self, ctx):
+        if ctx.invoked_subcommand is None:
+            await ctx.send('Please use one of the following subcommands: '
+                           'threshold <threshold>, positivechannel, negativechannel')
+
+    # The dasmooi settings command to update the threshold
+    @on_update_das_mooi_settings.command(name='threshold')
+    async def on_update_das_mooi_threshold(self, ctx, threshold: int):
+        await database.settings.set_das_mooi_threshold(threshold)
+        await ctx.send(f'Updated the das mooi threshold to: {threshold}.')
+
+    # The dasmooi settings command to update the positive forward channel to the current channel
+    @on_update_das_mooi_settings.command(name='positivechannel')
+    async def on_update_das_mooi_channel(self, ctx):
+        await database.settings.set_das_mooi_channel(ctx.channel.id)
+        await ctx.send(f'All positive messages which pass the das mooi threshold,'
+                       f' will be redirected to this channel')
+
+    # The dasmooi settings command to update the negative forward channel to the current channel
+    @on_update_das_mooi_settings.command(name='negativechannel')
+    async def on_update_das_niet_mooi_channel(self, ctx):
+        await database.settings.set_das_niet_mooi_channel(ctx.channel.id)
+        await ctx.send(f'All negative messages which pass the das mooi threshold,'
+                       f' will be redirected to this channel')
 
     # Returns a string in the following format:
     # {ranking}. {name} - {score} ({positives} Positives and {negatives} Negatives)
@@ -81,19 +124,20 @@ class Fun(commands.Cog):
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction: discord.Reaction, member: discord.Member):
-        await self.change_count(reaction, member, True)
+        await self.change_karma_check(reaction, member, True)
+        await self.forward_message_check(reaction)
 
     @commands.Cog.listener()
     async def on_reaction_remove(self, reaction: discord.Reaction, member: discord.Member):
-        await self.change_count(reaction, member, False)
+        await self.change_karma_check(reaction, member, False)
 
     class KarmaEmotes(enum.Enum):
         POSITIVE = 'dasmooi'
         NEGATIVE = 'dasnietmooi'
 
     # Check if the karma count should be changed, if so, change it
-    async def change_count(self, reaction: discord.Reaction, member: discord.Member,
-                           increment: bool):
+    async def change_karma_check(self, reaction: discord.Reaction, member: discord.Member,
+                                 increment: bool):
         # Check if the user doesn't want to give karma to themselves.
         # It is also important that Tegel's opinion doesn't count.
         if self.enabled and member != reaction.message.author \
@@ -110,16 +154,39 @@ class Fun(commands.Cog):
                     await database.update_karma(reaction.message.author.id,
                                                 (0, 1 if increment else -1))
 
-    # Replies "Alexa, play Despacito" to messages containing "this is so sad"
-    @commands.Cog.listener()
-    async def on_message(self, message: discord.Message):
-        if not self.enabled:
-            return
-        if message.author.bot:
-            return
-        if not "this is so sad" in message.content.lower():
-            return
-        await message.channel.send("Alexa, play Despacito")
+    # Check if the message obtained enough karma to get forwarded to another channel
+    async def forward_message_check(self, reaction: discord.Reaction):
+        message: discord.Message = reaction.message
+        if self.enabled and not message.author.bot \
+                and reaction.count >= database.settings.get_das_mooi_threshold() \
+                and message.id not in self.forwarded_messages:
+            emoji: discord.emoji.Emoji = reaction.emoji
+            if type(emoji) == discord.emoji.Emoji and (emoji.name == self.KarmaEmotes.POSITIVE.value
+                                                       or emoji.name ==
+                                                       self.KarmaEmotes.NEGATIVE.value):
+                self.forwarded_messages.append(message.id)
+                channel = self.bot.get_channel(
+                    database.settings.get_das_mooi_channel()) \
+                    if emoji.name == self.KarmaEmotes.POSITIVE.value \
+                    else self.bot.get_channel(database.settings.get_das_niet_mooi_channel())
+                await channel.send(
+                    f"A new message by {message.author.mention} arrived:\n"
+                    f"> {message.content}\n"
+                    f"> \n"
+                    f"> {message.jump_url}\n",
+                    files=await to_files(message.attachments))
+
+
+# Turn attachments into files
+async def to_files(attachments):
+    files = []
+
+    for attachment in attachments:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(attachment.url) as resp:
+                files.append(File(io.BytesIO(await resp.read()), filename=attachment.filename))
+    return files
+
 
 def setup(bot):
     bot.add_cog(Fun(bot))

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -79,6 +79,7 @@ class Fun(commands.Cog):
 
     # The base command for the dasmooi settings
     @commands.group(name='dasmooi')
+    @commands.is_owner()
     async def on_update_das_mooi_settings(self, ctx):
         if ctx.invoked_subcommand is None:
             await ctx.send('Please use one of the following subcommands: '

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -68,6 +68,7 @@ class Fun(commands.Cog):
 
     # The base command for the dasmooi settings
     @commands.group(name='dasmooi')
+    @commands.is_owner()
     async def on_update_das_mooi_settings(self, ctx):
         if ctx.invoked_subcommand is None:
             await ctx.send('Please use one of the following subcommands: '

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,7 +1,11 @@
 import enum
+import io
 import random
+import urllib
 
+import aiohttp
 import discord
+from discord import File
 from discord.ext import commands
 from discord.ext.commands import Context
 
@@ -12,6 +16,7 @@ class Fun(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.enabled = True
         self.bot = bot
+        self.forwarded_messages = []
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -61,6 +66,33 @@ class Fun(commands.Cog):
         message = self.order_leaderboard(await database.get_reversed_top_karma(10))
         await ctx.send(message if message else "Why don't you guys hate someone?")
 
+    # The base command for the dasmooi settings
+    @commands.group(name='dasmooi')
+    async def on_update_das_mooi_settings(self, ctx):
+        if ctx.invoked_subcommand is None:
+            await ctx.send('Please use one of the following subcommands: '
+                           'threshold <threshold>, positivechannel, negativechannel')
+
+    # The dasmooi settings command to update the threshold
+    @on_update_das_mooi_settings.command(name='threshold')
+    async def on_update_das_mooi_threshold(self, ctx, threshold: int):
+        await database.settings.set_das_mooi_threshold(threshold)
+        await ctx.send(f'Updated the das mooi threshold to: {threshold}.')
+
+    # The dasmooi settings command to update the positive forward channel to the current channel
+    @on_update_das_mooi_settings.command(name='positivechannel')
+    async def on_update_das_mooi_channel(self, ctx):
+        await database.settings.set_das_mooi_channel(ctx.channel.id)
+        await ctx.send(f'All positive messages which pass the das mooi threshold,'
+                       f' will be redirected to this channel')
+
+    # The dasmooi settings command to update the negative forward channel to the current channel
+    @on_update_das_mooi_settings.command(name='negativechannel')
+    async def on_update_das_niet_mooi_channel(self, ctx):
+        await database.settings.set_das_niet_mooi_channel(ctx.channel.id)
+        await ctx.send(f'All negative messages which pass the das mooi threshold,'
+                       f' will be redirected to this channel')
+
     # Returns a string in the following format:
     # {ranking}. {name} - {score} ({positives} Positives and {negatives} Negatives)
     def order_leaderboard(self, karma):
@@ -81,19 +113,20 @@ class Fun(commands.Cog):
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction: discord.Reaction, member: discord.Member):
-        await self.change_count(reaction, member, True)
+        await self.change_karma_check(reaction, member, True)
+        await self.forward_message_check(reaction)
 
     @commands.Cog.listener()
     async def on_reaction_remove(self, reaction: discord.Reaction, member: discord.Member):
-        await self.change_count(reaction, member, False)
+        await self.change_karma_check(reaction, member, False)
 
     class KarmaEmotes(enum.Enum):
         POSITIVE = 'dasmooi'
         NEGATIVE = 'dasnietmooi'
 
     # Check if the karma count should be changed, if so, change it
-    async def change_count(self, reaction: discord.Reaction, member: discord.Member,
-                           increment: bool):
+    async def change_karma_check(self, reaction: discord.Reaction, member: discord.Member,
+                                 increment: bool):
         # Check if the user doesn't want to give karma to themselves.
         # It is also important that Tegel's opinion doesn't count.
         if self.enabled and member != reaction.message.author \
@@ -109,6 +142,39 @@ class Fun(commands.Cog):
                     # Update the negative karma
                     await database.update_karma(reaction.message.author.id,
                                                 (0, 1 if increment else -1))
+
+    # Check if the message obtained enough karma to get forwarded to another channel
+    async def forward_message_check(self, reaction: discord.Reaction):
+        message: discord.Message = reaction.message
+        if self.enabled and not message.author.bot \
+                and reaction.count >= database.settings.get_das_mooi_threshold() \
+                and message.id not in self.forwarded_messages:
+            emoji: discord.emoji.Emoji = reaction.emoji
+            if type(emoji) == discord.emoji.Emoji and (emoji.name == self.KarmaEmotes.POSITIVE.value
+                                                       or emoji.name ==
+                                                       self.KarmaEmotes.NEGATIVE.value):
+                self.forwarded_messages.append(message.id)
+                channel = self.bot.get_channel(
+                    database.settings.get_das_mooi_channel()) \
+                    if emoji.name == self.KarmaEmotes.POSITIVE.value \
+                    else self.bot.get_channel(database.settings.get_das_niet_mooi_channel())
+                await channel.send(
+                    f"A new message by {message.author.mention} arrived:\n"
+                    f"> {message.content}\n"
+                    f"> \n"
+                    f"> {message.jump_url}\n",
+                    files=await to_files(message.attachments))
+
+
+# Turn attachments into files
+async def to_files(attachments):
+    files = []
+
+    for attachment in attachments:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(attachment.url) as resp:
+                files.append(File(io.BytesIO(await resp.read()), filename=attachment.filename))
+    return files
 
 
 def setup(bot):


### PR DESCRIPTION
When a message receives enough dasmooi emotes to exceed the threshold, the message will be forwarded to channel, dedicated to receiving these messages.
The same is true for messages that receive enough dasnietmooi emotes, but they get forwarded to their own channel.

The threshold and channel can be changed by using the `.dasmooi` command.
This command can only be executed by the owner of the bot.
