### PR TITLE
Open the database on bot start and reuse that connection

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -21,4 +21,3 @@ houses = {
     'TakingCtrl':'Green',
     'Fearless':'Green'
 }
-DATABASE_LOCATION = 'tcs_bot.db'

--- a/backend/config.py
+++ b/backend/config.py
@@ -21,3 +21,4 @@ houses = {
     'TakingCtrl':'Green',
     'Fearless':'Green'
 }
+DATABASE_LOCATION = 'tcs_bot.db'

--- a/backend/database.py
+++ b/backend/database.py
@@ -2,8 +2,6 @@ import sqlite3
 import aiosqlite
 import inspect
 
-# print(self.bot._db)
-
 from backend.config import DATABASE_LOCATION
 
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -31,17 +31,17 @@ class Settings:
     def get_das_niet_mooi_channel(self) -> int:
         return self._das_niet_mooi_channel
 
-    async def set_das_mooi_threshold(self, das_mooi_threshold: int) -> None:
+    async def set_das_mooi_threshold(self, connection, das_mooi_threshold: int) -> None:
         self._das_mooi_threshold = das_mooi_threshold
-        await _update_settings(self)
+        await _update_settings(connection)
 
-    async def set_das_mooi_channel(self, das_mooi_channel: int) -> None:
+    async def set_das_mooi_channel(self, connection, das_mooi_channel: int) -> None:
         self._das_mooi_channel = das_mooi_channel
-        await _update_settings(self)
+        await _update_settings(connection)
 
-    async def set_das_niet_mooi_channel(self, das_niet_mooi_channel: int) -> None:
+    async def set_das_niet_mooi_channel(self, connection, das_niet_mooi_channel: int) -> None:
         self._das_niet_mooi_channel = das_niet_mooi_channel
-        await _update_settings(self)
+        await _update_settings(connection)
 
 
 # Create the default structure
@@ -111,8 +111,7 @@ def create_tables() -> Settings:
 
 
 # Update the settings in the database
-async def _update_settings(self) -> None:
-  connection = self.bot._db
+async def _update_settings(connection) -> None:
   await connection.execute("UPDATE setting SET "
                            "das_mooi_threshold=?, "
                            "das_mooi_channel=?, "

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,7 +4,7 @@ import inspect
 
 # print(self.bot._db)
 
-DATABASE_LOCATION = 'tcs_bot.db'
+from backend.config import DATABASE_LOCATION
 
 
 class Settings:

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,6 +1,8 @@
 import sqlite3
-
 import aiosqlite
+import inspect
+
+# print(self.bot._db)
 
 DATABASE_LOCATION = 'tcs_bot.db'
 
@@ -31,15 +33,15 @@ class Settings:
 
     async def set_das_mooi_threshold(self, das_mooi_threshold: int) -> None:
         self._das_mooi_threshold = das_mooi_threshold
-        await _update_settings()
+        await _update_settings(self)
 
     async def set_das_mooi_channel(self, das_mooi_channel: int) -> None:
         self._das_mooi_channel = das_mooi_channel
-        await _update_settings()
+        await _update_settings(self)
 
     async def set_das_niet_mooi_channel(self, das_niet_mooi_channel: int) -> None:
         self._das_niet_mooi_channel = das_niet_mooi_channel
-        await _update_settings()
+        await _update_settings(self)
 
 
 # Create the default structure
@@ -109,134 +111,140 @@ def create_tables() -> Settings:
 
 
 # Update the settings in the database
-async def _update_settings() -> None:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        await connection.execute("UPDATE setting SET "
-                                 "das_mooi_threshold=?, "
-                                 "das_mooi_channel=?, "
-                                 "das_niet_mooi_channel=?;", (settings.get_das_mooi_threshold(),
-                                                              settings.get_das_mooi_channel(),
-                                                              settings.get_das_niet_mooi_channel()))
-        await connection.commit()
+async def _update_settings(self) -> None:
+  connection = self.bot._db
+  await connection.execute("UPDATE setting SET "
+                           "das_mooi_threshold=?, "
+                           "das_mooi_channel=?, "
+                           "das_niet_mooi_channel=?;", (settings.get_das_mooi_threshold(),
+                                                        settings.get_das_mooi_channel(),
+                                                        settings.get_das_niet_mooi_channel()))
+  await connection.commit()
 
 
 # Get the leading karma users
-async def get_top_karma(limit: int) -> [(int, int, int)]:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        async with connection.execute("SELECT u.discord_id, k.positive, k.negative "
-                                      "FROM user u "
-                                      "JOIN karma k ON u.id = k.user_id "
-                                      "WHERE k.positive <> 0 OR k.negative <> 0 "
-                                      "ORDER BY (k.positive - k.negative) DESC "
-                                      "LIMIT ?;", [limit]) as cursor:
-            leaders = await cursor.fetchall()
-            return leaders if leaders else []
+async def get_top_karma(self, limit: int) -> [(int, int, int)]:
+  connection = self.bot._db
+  cursor = await connection.execute("SELECT u.discord_id, k.positive, k.negative "
+                                    "FROM user u "
+                                    "JOIN karma k ON u.id = k.user_id "
+                                    "WHERE k.positive <> 0 OR k.negative <> 0 "
+                                    "ORDER BY (k.positive - k.negative) DESC "
+                                    "LIMIT ?;", [limit])
+  leaders = await cursor.fetchall()
+  await cursor.close()
+  return leaders if leaders else []
 
 
 # Get the leading negative karma users
-async def get_reversed_top_karma(limit: int) -> [(int, int, int)]:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        async with connection.execute("SELECT u.discord_id, k.positive, k.negative "
+async def get_reversed_top_karma(self, limit: int) -> [(int, int, int)]:
+  connection = self.bot._db
+  cursor = await connection.execute("SELECT u.discord_id, k.positive, k.negative "
                                       "FROM user u "
                                       "JOIN karma k ON u.id = k.user_id "
                                       "WHERE k.positive <> 0 OR k.negative <> 0 "
                                       "ORDER BY (k.positive - k.negative) ASC "
-                                      "LIMIT ?;", [limit]) as cursor:
-            leaders = await cursor.fetchall()
-            return leaders if leaders else []
+                                      "LIMIT ?;", [limit])
+  leaders = await cursor.fetchall()
+  await cursor.close()
+  return leaders if leaders else []
 
 
 # Get the karma for a specific user
-async def get_karma(discord_id: int) -> (int, int):
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        async with connection.execute("SELECT k.positive, k.negative "
-                                      "FROM user u "
-                                      "JOIN karma k ON u.id = k.user_id "
-                                      "WHERE u.discord_id=?;", [discord_id]) as cursor:
-            karma = await cursor.fetchone()
-            return karma if karma else (0, 0)
+async def get_karma(self, discord_id: int) -> (int, int):
+  connection = self.bot._db
+  cursor = await connection.execute("SELECT k.positive, k.negative "
+                                    "FROM user u "
+                                    "JOIN karma k ON u.id = k.user_id "
+                                    "WHERE u.discord_id=?;", [discord_id])
+  karma = await cursor.fetchone()
+  return karma if karma else (0, 0)
 
 
 # Update the karma counts for a specific user
-async def update_karma(discord_id: int, karma: (int, int)) -> None:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        await connection.execute("INSERT OR IGNORE INTO user (discord_id) VALUES (?);",
-                                 [discord_id])
-        await connection.execute("INSERT INTO karma "
-                                 "(user_id, positive, negative) "
-                                 "VALUES ((SELECT id FROM user WHERE discord_id=?), ?, ?) "
-                                 "ON CONFLICT(user_id) DO UPDATE SET "
-                                 "positive = positive + ?, "
-                                 "negative = negative + ?;",
-                                 [discord_id, max(karma[0], 0), max(karma[1], 0), karma[0],
-                                  karma[1]])
-        await connection.commit()
+async def update_karma(self, discord_id: int, karma: (int, int)) -> None:
+  connection = self.bot._db
+  await connection.execute("INSERT OR IGNORE INTO user (discord_id) VALUES (?);",
+                           [discord_id])
+  await connection.execute("INSERT INTO karma "
+                           "(user_id, positive, negative) "
+                           "VALUES ((SELECT id FROM user WHERE discord_id=?), ?, ?) "
+                           "ON CONFLICT(user_id) DO UPDATE SET "
+                           "positive = positive + ?, "
+                           "negative = negative + ?;",
+                           [discord_id, max(karma[0], 0), max(karma[1], 0), karma[0],
+                            karma[1]])
+  await connection.commit()
 
 
 # Get the most laffe users
-async def get_top_laf(limit: int) -> [(int, int)]:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        async with connection.execute("SELECT u.discord_id, l.count "
-                                      "FROM user u "
-                                      "JOIN laf_counter l ON u.id = l.user_id "
-                                      "ORDER BY (l.count) DESC "
-                                      "LIMIT ?;", [limit]) as cursor:
-            leaders = await cursor.fetchall()
-            return leaders if leaders else []
+async def get_top_laf(self, limit: int) -> [(int, int)]:
+  connection = self.bot._db
+  cursor = await connection.execute("SELECT u.discord_id, l.count "
+                                    "FROM user u "
+                                    "JOIN laf_counter l ON u.id = l.user_id "
+                                    "ORDER BY (l.count) DESC "
+                                    "LIMIT ?;", [limit])
+  leaders = await cursor.fetchall()
+  await cursor.close()
+  return leaders if leaders else []
 
 
 # Get the least laffe users
-async def get_reversed_top_laf(limit: int) -> [(int, int)]:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        async with connection.execute("SELECT u.discord_id, l.count "
+async def get_reversed_top_laf(self, limit: int) -> [(int, int)]:
+  connection = self.bot._db
+  cursor = await connection.execute("SELECT u.discord_id, l.count "
                                       "FROM user u "
                                       "JOIN laf_counter l ON u.id = l.user_id "
                                       "ORDER BY (l.count) ASC "
-                                      "LIMIT ?;", [limit]) as cursor:
-            leaders = await cursor.fetchall()
-            return leaders if leaders else []
+                                      "LIMIT ?;", [limit])
+  leaders = await cursor.fetchall()
+  await cursor.close()
+  return leaders if leaders else []
 
 
 # Get the laf_counter for a specific user
-async def get_laf(discord_id: int) -> int:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        async with connection.execute("SELECT l.count "
-                                      "FROM user u "
-                                      "JOIN laf_counter l ON u.id = l.user_id "
-                                      "WHERE u.discord_id=?;", [discord_id]) as cursor:
-            laf_counter = await cursor.fetchone()
-            return laf_counter[0] if laf_counter else 0
-
+async def get_laf(self, discord_id: int) -> int:
+  connection = self.bot._db
+  cursor = await connection.execute("SELECT l.count "
+                                "FROM user u "
+                                "JOIN laf_counter l ON u.id = l.user_id "
+                                "WHERE u.discord_id=?;", [discord_id])
+  laf_counter = await cursor.fetchone()
+  await cursor.close()
+  return laf_counter[0] if laf_counter else 0
 
 # Update the laf_counter for a specific user
-async def update_laf(discord_id: int, count: int) -> None:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        await connection.execute("INSERT OR IGNORE INTO user (discord_id) VALUES (?);",
-                                 [discord_id])
-        await connection.execute("INSERT INTO laf_counter "
-                                 "(user_id, count) "
-                                 "VALUES ((SELECT id FROM user WHERE discord_id=?), ?) "
-                                 "ON CONFLICT(user_id) DO UPDATE SET "
-                                 "count = count + ?; ",
-                                 [discord_id, max(count, 0), count ])
-        await connection.commit()
+async def update_laf(self, discord_id: int, count: int) -> None:
+  connection = self.bot._db
+  await connection.execute("INSERT OR IGNORE INTO user (discord_id) VALUES (?);",
+                           [discord_id])
+  await connection.execute("INSERT INTO laf_counter "
+                           "(user_id, count) "
+                           "VALUES ((SELECT id FROM user WHERE discord_id=?), ?) "
+                           "ON CONFLICT(user_id) DO UPDATE SET "
+                           "count = count + ?; ",
+                           [discord_id, max(count, 0), count ])
+  await connection.commit()
 
 
-async def is_forwarded(message_id: int, positive: bool) -> bool:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        async with connection.execute("SELECT message_id "
+async def is_forwarded(self, message_id: int, positive: bool) -> bool:
+  connection = self.bot._db
+  cursor = await connection.execute("SELECT message_id "
                                       "FROM forwarded_messages "
                                       "WHERE message_id=? AND positive=?;",
-                                      (message_id, positive)) as cursor:
-            return await cursor.fetchone() is not None
+                                      (message_id, positive))
+  result = await cursor.fetchone()
+  await cursor.close()
+  return result is not None
 
 
-async def add_forwarded_message(message_id: int, positive: bool) -> None:
-    async with aiosqlite.connect(DATABASE_LOCATION) as connection:
-        await connection.execute("INSERT INTO forwarded_messages "
-                                 "(message_id, positive) "
-                                 "VALUES (?, ?);", (message_id, positive))
-        await connection.commit()
+async def add_forwarded_message(self, message_id: int, positive: bool) -> None:
+  connection = self.bot._db
+  await connection.execute("INSERT INTO forwarded_messages "
+                         "(message_id, positive) "
+                         "VALUES (?, ?);", (message_id, positive))
+  await connection.commit()
 
 
 # Set up the defaults

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,7 +4,7 @@ import inspect
 
 # print(self.bot._db)
 
-from backend.config import DATABASE_LOCATION
+DATABASE_LOCATION = 'tcs_bot.db'
 
 
 class Settings:

--- a/backend/main_guild.py
+++ b/backend/main_guild.py
@@ -1,4 +1,4 @@
 # Main server that the bot uses
 # (used so that only dasmooi-karma from one server counts)
 # TCS server has id: 613755161633882112
-main_guild = 303962809627181057 
+main_guild = 613755161633882112 

--- a/backend/main_guild.py
+++ b/backend/main_guild.py
@@ -1,4 +1,4 @@
 # Main server that the bot uses
 # (used so that only dasmooi-karma from one server counts)
 # TCS server has id: 613755161633882112
-main_guild = 613755161633882112 
+main_guild = 303962809627181057 

--- a/cogs/dasmooi.py
+++ b/cogs/dasmooi.py
@@ -37,20 +37,23 @@ class DasMooi(commands.Cog):
     # The dasmooi settings command to update the threshold
     @on_update_das_mooi_settings.command(name='threshold')
     async def on_update_das_mooi_threshold(self, ctx, threshold: int):
-        await database.settings.set_das_mooi_threshold(self,threshold)
+        connection = self.bot._db
+        await database.settings.set_das_mooi_threshold(connection,threshold)
         await ctx.send(f'Updated the das mooi threshold to: {threshold}.')
 
     # The dasmooi settings command to update the positive forward channel to the current channel
     @on_update_das_mooi_settings.command(name='positivechannel')
     async def on_update_das_mooi_channel(self, ctx):
-        await database.settings.set_das_mooi_channel(self,ctx.channel.id)
+        connection = self.bot._db
+        await database.settings.set_das_mooi_channel(connection,ctx.channel.id)
         await ctx.send(f'All positive messages which pass the das mooi threshold,'
                        f' will be redirected to this channel')
 
     # The dasmooi settings command to update the negative forward channel to the current channel
     @on_update_das_mooi_settings.command(name='negativechannel')
     async def on_update_das_niet_mooi_channel(self, ctx):
-        await database.settings.set_das_niet_mooi_channel(self,ctx.channel.id)
+        connection = self.bot._db
+        await database.settings.set_das_niet_mooi_channel(connection,ctx.channel.id)
         await ctx.send(f'All negative messages which pass the das mooi threshold,'
                        f' will be redirected to this channel')
 

--- a/cogs/dasmooi.py
+++ b/cogs/dasmooi.py
@@ -37,20 +37,20 @@ class DasMooi(commands.Cog):
     # The dasmooi settings command to update the threshold
     @on_update_das_mooi_settings.command(name='threshold')
     async def on_update_das_mooi_threshold(self, ctx, threshold: int):
-        await database.settings.set_das_mooi_threshold(threshold)
+        await database.settings.set_das_mooi_threshold(self,threshold)
         await ctx.send(f'Updated the das mooi threshold to: {threshold}.')
 
     # The dasmooi settings command to update the positive forward channel to the current channel
     @on_update_das_mooi_settings.command(name='positivechannel')
     async def on_update_das_mooi_channel(self, ctx):
-        await database.settings.set_das_mooi_channel(ctx.channel.id)
+        await database.settings.set_das_mooi_channel(self,ctx.channel.id)
         await ctx.send(f'All positive messages which pass the das mooi threshold,'
                        f' will be redirected to this channel')
 
     # The dasmooi settings command to update the negative forward channel to the current channel
     @on_update_das_mooi_settings.command(name='negativechannel')
     async def on_update_das_niet_mooi_channel(self, ctx):
-        await database.settings.set_das_niet_mooi_channel(ctx.channel.id)
+        await database.settings.set_das_niet_mooi_channel(self,ctx.channel.id)
         await ctx.send(f'All negative messages which pass the das mooi threshold,'
                        f' will be redirected to this channel')
 
@@ -68,7 +68,7 @@ class DasMooi(commands.Cog):
         """
         Show the dasmooi-karma leaderboard
         """
-        message = self.order_leaderboard(await database.get_top_karma(10))
+        message = self.order_leaderboard(await database.get_top_karma(self,10))
         await ctx.send(message if message else 'Nobody is mooi')
 
     # Send the negative leaderboards in the following format:
@@ -80,7 +80,7 @@ class DasMooi(commands.Cog):
         """
         Show the negative dasmooi-karma leaderboard
         """
-        message = self.order_leaderboard(await database.get_reversed_top_karma(10))
+        message = self.order_leaderboard(await database.get_reversed_top_karma(self,10))
         await ctx.send(message if message else "Why don't you guys hate someone?")
 
 
@@ -100,7 +100,7 @@ class DasMooi(commands.Cog):
         Show how much dasmooi-karma you have
         """
         author: discord.User = ctx.author
-        response: (int, int) = await database.get_karma(author.id)
+        response: (int, int) = await database.get_karma(self,author.id)
         await ctx.send(
             f'{author.mention} - Your current score is: **{response[0] - response[1]}** '
             f'*({response[0]} Positives and {response[1]} Negatives)*')
@@ -112,7 +112,7 @@ class DasMooi(commands.Cog):
         """
         Show how much dasmooi-karma someone has
         """
-        response: (int, int) = await database.get_karma(user.id)
+        response: (int, int) = await database.get_karma(self,user.id)
         await ctx.send(
             f'{user.name}\'s current score is: **{response[0] - response[1]}** '
             f'*({response[0]} Positives and {response[1]} Negatives)*')
@@ -154,11 +154,11 @@ class DasMooi(commands.Cog):
                 and not discord.utils.get(member.roles, name='Tegel'):
             if emoji.name == self.KarmaEmotes.POSITIVE.value:
                 # Update the positive karma
-                await database.update_karma(message.author.id,
+                await database.update_karma(self,message.author.id,
                                             (1 if increment else -1, 0))
             elif emoji.name == self.KarmaEmotes.NEGATIVE.value:
                 # Update the negative karma
-                await database.update_karma(message.author.id,
+                await database.update_karma(self,message.author.id,
                                             (0, 1 if increment else -1))
 
     # Check if the message obtained enough karma to get forwarded to another channel
@@ -172,8 +172,8 @@ class DasMooi(commands.Cog):
             if emoji.name == self.KarmaEmotes.POSITIVE.value \
                     or emoji.name == self.KarmaEmotes.NEGATIVE.value:
                 positive: bool = emoji.name == self.KarmaEmotes.POSITIVE.value
-                if not await database.is_forwarded(message.id, positive):
-                    await database.add_forwarded_message(message.id, positive)
+                if not await database.is_forwarded(self, message.id, positive):
+                    await database.add_forwarded_message(self, message.id, positive)
                     channel = self.bot.get_channel(
                         database.settings.get_das_mooi_channel()) \
                         if positive \

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,4 +1,6 @@
 import random
+import requests
+import time
 
 import discord
 from discord.ext import commands
@@ -51,6 +53,46 @@ class Fun(commands.Cog):
         if "this is so sad" not in message.content.lower():
             return
         await message.channel.send("Alexa, play Despacito")
+
+    @commands.command(name="vb")
+    async def vb(self, ctx):
+        """
+        Check if VB is open and, if it is, send a screenshot of the webcam
+        """
+        try:
+            async with ctx.channel.typing():
+                webpage = requests.get("https://www.vestingbar.nl/en/")
+                webpage = webpage.content.decode('utf-8')
+        except ConnectionError:
+            msg = "Cannot reach vestingbar.nl, is it down?"
+            open = False
+
+        if 'gfx/SignOpen.png' in webpage:
+            msg = "Vestingbar seems to be open"
+            open = True
+        elif 'gfx/SignClosed.png' in webpage:
+            msg = "Vestingbar seems to be closed"
+            open = False
+        else:
+            msg = "Can't determine if vestingbar is open, did they change their webpage?"
+            open = False
+
+        if open:
+            colour = discord.colour.Colour.green()
+            img = "https://www.vestingbar.nl/webcam-images/image.jpg?"+str(time.time())
+        else:
+            colour = discord.colour.Colour.red()
+            img = ''
+
+
+        embed: discord.Embed = discord.Embed(title="Is VB open?",
+                                             description=msg,
+                                             url='https://www.vestingbar.nl/en/',
+                                             colour=colour)
+        embed.set_image(url=img)
+        
+
+        await ctx.send(embed=embed)
 
 def setup(bot):
     bot.add_cog(Fun(bot))

--- a/cogs/laf.py
+++ b/cogs/laf.py
@@ -66,7 +66,7 @@ class Laf(commands.Cog):
 
     # Send a current status for the player that requested it in the following format:
     # {mention} - Your were called laf {score}x
-    @commands.command(name='hoelafbenik', aliases=['howlafami',','])
+    @commands.command(name='hoelafbenik', aliases=['howlafami'])
     async def on_karma_self_request(self, ctx: Context):
         """
         Show how laf you are

--- a/cogs/laf.py
+++ b/cogs/laf.py
@@ -32,7 +32,7 @@ class Laf(commands.Cog):
             return
         
         for mention in message.mentions:
-            await database.update_laf(mention.id, 1)
+            await database.update_laf(self,mention.id, 1)
 
     # Send the leaderboards:
     @commands.command(name='wiezijnhetlafst',
@@ -42,7 +42,7 @@ class Laf(commands.Cog):
         """
         Show the most laf users
         """
-        message = self.order_leaderboard(await database.get_top_karma(10))
+        message = self.order_leaderboard(await database.get_top_laf(self,10))
         await ctx.send(message if message else 'Nobody is mooi')
 
     # Send the negative leaderboards:
@@ -53,7 +53,7 @@ class Laf(commands.Cog):
         """
         Show the least laf users
         """
-        message = self.order_leaderboard(await database.get_reversed_top_laf(10))
+        message = self.order_leaderboard(await database.get_reversed_top_laf(self,10))
         await ctx.send(message if message else "Why don't you guys call someone laf? @P1mguin, for example")
 
 
@@ -66,13 +66,13 @@ class Laf(commands.Cog):
 
     # Send a current status for the player that requested it in the following format:
     # {mention} - Your were called laf {score}x
-    @commands.command(name='hoelafbenik', aliases=['howlafami'])
+    @commands.command(name='hoelafbenik', aliases=['howlafami',','])
     async def on_karma_self_request(self, ctx: Context):
         """
         Show how laf you are
         """
         author: discord.User = ctx.author
-        response: (int, int) = await database.get_laf(author.id)
+        response: (int, int) = await database.get_laf(self,author.id)
         await ctx.send(
             f'{author.mention} - Your were called laf {response}x ')
 
@@ -83,7 +83,7 @@ class Laf(commands.Cog):
         """
         Show how laf someone is
         """
-        response: (int, int) = await database.get_laf(user.id)
+        response: (int, int) = await database.get_laf(self,user.id)
         await ctx.send(
             f'{user.name} has been called laf {response}x ')
 

--- a/cogs/laf.py
+++ b/cogs/laf.py
@@ -26,10 +26,10 @@ class Laf(commands.Cog):
         # im sorry about the try catch block
         try:
             ctx = await bot.get_context(message)
+            if ctx.valid:
+                return
         except NameError:
-            pass  
-        if ctx.valid:
-            return
+            pass
         
         for mention in message.mentions:
             await database.update_laf(self,mention.id, 1)

--- a/cogs/laf.py
+++ b/cogs/laf.py
@@ -27,7 +27,7 @@ class Laf(commands.Cog):
         try:
             ctx = await bot.get_context(message)
         except NameError:
-            return  
+            pass  
         if ctx.valid:
             return
         

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 import aiohttp
+import aiosqlite
+import asyncio
+
 import discord
 from discord.ext import commands
 
-import aiosqlite
 DATABASE_LOCATION = 'tcs_bot.db'
 
 if __name__ == "__main__":
@@ -13,7 +15,6 @@ bot = commands.Bot(".", case_insensitive=True)
 
 @bot.event
 async def on_ready():
-    bot._db = await aiosqlite.connect(DATABASE_LOCATION)
     bot._session = aiohttp.ClientSession()
     print('Logged in as')
     print(bot.user.name)
@@ -21,8 +22,11 @@ async def on_ready():
     print('------')
     print(discord.utils.oauth_url(bot.user.id))
 
+async def connect_db():
+    bot._db = await aiosqlite.connect(DATABASE_LOCATION)
 
 if __name__ == "__main__":
+    bot.loop.run_until_complete(connect_db())
     extensions = [
         "cogs.rolehelper",
         "cogs.moderation",

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import asyncio
 import discord
 from discord.ext import commands
 
-from backend.config import DATABASE_LOCATION
+DATABASE_LOCATION = 'tcs_bot.db'
 
 if __name__ == "__main__":
     with open("token.txt") as file:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,9 @@ import aiohttp
 import discord
 from discord.ext import commands
 
+import aiosqlite
+DATABASE_LOCATION = 'tcs_bot.db'
+
 if __name__ == "__main__":
     with open("token.txt") as file:
         TOKEN = file.read().strip()
@@ -10,12 +13,14 @@ bot = commands.Bot(".", case_insensitive=True)
 
 @bot.event
 async def on_ready():
+    bot._db = await aiosqlite.connect(DATABASE_LOCATION)
     bot._session = aiohttp.ClientSession()
     print('Logged in as')
     print(bot.user.name)
     print(bot.user.id)
     print('------')
     print(discord.utils.oauth_url(bot.user.id))
+
 
 if __name__ == "__main__":
     extensions = [

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import asyncio
 import discord
 from discord.ext import commands
 
-DATABASE_LOCATION = 'tcs_bot.db'
+from backend.config import DATABASE_LOCATION
 
 if __name__ == "__main__":
     with open("token.txt") as file:


### PR DESCRIPTION
In this PR the problem that the database would try to be reopened when there was already a connection is fixed, the connection is now a member of the bot instance.

I also fixed some dumb bugs I had in the laf counter and moved `DATABASE_LOCATION` to `backend/config.py`, so that you don't have to specify it in both `main.py` and `backend/database.py`